### PR TITLE
SetSpeed() メソッドを PlayableDirector に生やす

### DIFF
--- a/Assets/Scripts/UnityModule/Playables/PlayableExtension.cs
+++ b/Assets/Scripts/UnityModule/Playables/PlayableExtension.cs
@@ -107,6 +107,10 @@ namespace UnityModule.Playables {
             playableDirector.RebuildGraph();
         }
 
+        public static void SetSpeed(this PlayableDirector playableDirector, int speed, int rootPlayableIndex = 0) {
+            playableDirector.playableGraph.GetRootPlayable(rootPlayableIndex).SetSpeed(speed);
+        }
+
         private static IEnumerable<PlayableBinding> FindAllPlayableBinding(this PlayableAsset playableAsset, Func<string, PlayableAsset, bool> conditionForPlayableAsset = null) {
             return playableAsset
                 .outputs


### PR DESCRIPTION
* `.Pause()` だと状態が初期化されてしまうため、アニメーションとかを止める用に用意した